### PR TITLE
Updates scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ angular-teams.zip
 # System files
 .DS_Store
 Thumbs.db
+
+# Per-dev files
+.m365rc.json

--- a/.m365rc.json
+++ b/.m365rc.json
@@ -1,8 +1,0 @@
-{
-  "apps": [
-    {
-      "appId": "07169315-ee45-4006-835d-479d13bd0061",
-      "name": "Angular Teams app"
-    }
-  ]
-}

--- a/aad-app-manifest.json
+++ b/aad-app-manifest.json
@@ -4,7 +4,7 @@
   "accessTokenAcceptedVersion": null,
   "addIns": [],
   "allowPublicClient": null,
-  "appId": "07169315-ee45-4006-835d-479d13bd0061",
+  "appId": "fc51be1e-1870-4300-a6e6-e853c57577b4",
   "appRoles": [],
   "oauth2AllowUrlPathMatching": false,
   "createdDateTime": "2022-02-07T08:51:18Z",
@@ -13,7 +13,7 @@
   "disabledByMicrosoftStatus": null,
   "groupMembershipClaims": null,
   "identifierUris": [
-    "api://myuniquedomain.loca.lt/07169315-ee45-4006-835d-479d13bd0061"
+    "api://myuniquedomain.loca.lt/fc51be1e-1870-4300-a6e6-e853c57577b4"
   ],
   "informationalUrls": {
     "termsOfService": null,
@@ -48,6 +48,20 @@
     "legalAgeGroupRule": "Allow"
   },
   "passwordCredentials": [],
+  "preAuthorizedApplications": [
+    {
+      "appId": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346",
+      "permissionIds": [
+        "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5"
+      ]
+    },
+    {
+      "appId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+      "permissionIds": [
+        "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5"
+      ]
+    }
+  ],
   "publisherDomain": "M365x61791022.onmicrosoft.com",
   "replyUrlsWithType": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@angular-devkit/build-angular": "~13.2.2",
         "@angular/cli": "~13.2.2",
         "@angular/compiler-cli": "~13.2.0",
-        "@pnp/cli-microsoft365": "^4.4.0",
+        "@pnp/cli-microsoft365": "^5.0.0",
         "@types/jasmine": "~3.10.0",
         "@types/node": "^12.11.1",
         "bestzip": "^2.2.0",
@@ -2437,34 +2437,34 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365/-/cli-microsoft365-4.4.0.tgz",
-      "integrity": "sha512-THENBs7lBaBaCM1x8DyGpnYAd0flKiBy7Su3PtEmD24yHWDdlH2bj0un4KwMuCPWj5yRjCMzc76ebjQVZ/7JuQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365/-/cli-microsoft365-5.0.0.tgz",
+      "integrity": "sha512-SwvVVmuhPHKgTY/zotF7p2OaoNb55+jA6WZkKdfUdxuihnd08GbG9dLhR3CeDZXWahI23ZSg1C056x3btynS7g==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
-        "@azure/msal-node": "^1.5.0",
+        "@azure/msal-node": "^1.6.0",
         "@xmldom/xmldom": "^0.7.5",
         "adaptive-expressions": "^4.15.0",
         "adaptivecards": "^2.10.0",
         "adaptivecards-templating": "^2.2.0",
         "adm-zip": "^0.5.9",
-        "applicationinsights": "^2.2.0",
-        "axios": "^0.24.0",
+        "applicationinsights": "^2.2.1",
+        "axios": "^0.25.0",
         "chalk": "^4.1.2",
         "csv-stringify": "^6.0.5",
         "easy-table": "^1.2.0",
         "inquirer": "^8.2.0",
-        "jmespath": "^0.15.0",
+        "jmespath": "^0.16.0",
         "json-to-ast": "^2.1.0",
         "markshell": "^1.3.8",
         "minimist": "^1.2.5",
-        "node-forge": "^1.2.0",
+        "node-forge": "^1.2.1",
         "omelette": "^0.4.17",
         "open": "^8.4.0",
         "semver": "^7.3.4",
         "strip-json-comments": "^3.1.1",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "update-notifier": "^5.1.0",
         "uuid": "^8.3.2"
       },
@@ -2523,9 +2523,9 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@azure/core-http": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.2.tgz",
-      "integrity": "sha512-V1DdoO9V/sFimKpdWoNBgsE+QUjQgpXYnxrTdUp5RyhsTJjvEVn/HKmTQXIHuLUUo6IyIWj+B+Dg4VaXse9dIA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.4.tgz",
+      "integrity": "sha512-QmmJmexXKtPyc3/rsZR/YTLDvMatzbzAypJmLzvlfxgz/SkgnqV/D4f6F2LsK6tBj1qhyp8BoXiOebiej0zz3A==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -2536,7 +2536,7 @@
         "@types/node-fetch": "^2.5.0",
         "@types/tunnel": "^0.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
@@ -2606,9 +2606,9 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@azure/msal-common": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
-      "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1"
@@ -2618,13 +2618,14 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@azure/msal-node": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.5.0.tgz",
-      "integrity": "sha512-FiCra/3ZyLXSQltoI9ndeN/lvXsPsFDsqVKgH7SWXVQjL3OpEXiqKkj0CB2UWGCk1U6bZGMJfkUZCXzhMQTObQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.6.0.tgz",
+      "integrity": "sha512-RCPXVWsjqYZh7NB1pAJLn4ypHlLBulOjw5nKPLsJiaJJIXnN8kc6SMkK3S9/80DZCEBstvoRMz6zF50QZJUeOQ==",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "^6.0.0",
+        "@azure/msal-common": "^6.1.0",
         "axios": "^0.21.4",
+        "https-proxy-agent": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
@@ -2715,9 +2716,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@microsoft/microsoft-graph-types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.11.0.tgz",
-      "integrity": "sha512-v4Wuxp+kbcxeJGmb2UHbcukNr05XItFYXL+U3ReignI3Vl8tp1vfq0hkqP35Fun2QpqHJiu8Rkxj1MUF8d82ag==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.13.0.tgz",
+      "integrity": "sha512-63FfWBLcyNo8tMP4oPcdqHQvk4ehuWpiUMjVLD7zJXPENIowpdwudP969AALkKzlwsjWImamdivGKd2Zc8Z1Uw==",
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@microsoft/recognizers-text-data-types-timex-expression": {
@@ -2765,96 +2766,66 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/api": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-      "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
-      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "semver": "^7.1.3"
+        "@opentelemetry/semantic-conventions": "1.0.1"
       },
       "engines": {
         "node": ">=8.5.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
+        "@opentelemetry/api": ">=1.0.0 <1.1.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/resources": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
-      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+      "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0"
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
       },
       "engines": {
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
+        "@opentelemetry/api": ">=1.0.0 <1.1.0"
       }
     },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
+    "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+      "integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
       "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/resources": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
+      },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.1.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/tracing": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.23.0.tgz",
-      "integrity": "sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==",
-      "deprecated": "Package renamed to @opentelemetry/sdk-trace-base",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/resources": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@opentelemetry/tracing/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+      "integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -2879,18 +2850,18 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz",
+      "integrity": "sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==",
       "extraneous": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@sinonjs/samsam": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
       "extraneous": true,
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
@@ -2914,6 +2885,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/adm-zip": {
@@ -2944,9 +2924,9 @@
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/inquirer": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
-      "integrity": "sha512-AayK4ZL5ssPzR1OtnOLGAwpT0Dda3Xi/h1G0l1oJDNrowp7T1423q4Zb8/emr7tzRlCy4ssEri0LWVexAqHyKQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-BNoMetRf3gmkpAlV5we+kxyZTle7YibdOntIZbU5pyIfMdcwy784KfeZDAcuyMznkh5OLa17RVXZOGA5LTlkgQ==",
       "extraneous": true,
       "dependencies": {
         "@types/through": "*",
@@ -3011,15 +2991,15 @@
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/mocha": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/node": {
-      "version": "16.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+      "version": "16.11.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
+      "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/node-fetch": {
@@ -3062,13 +3042,19 @@
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/sinon": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
-      "integrity": "sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
+      "integrity": "sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==",
       "extraneous": true,
       "dependencies": {
-        "@sinonjs/fake-timers": "^7.1.0"
+        "@types/sinonjs__fake-timers": "*"
       }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@types/through": {
       "version": "0.0.30",
@@ -3111,14 +3097,14 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
-      "integrity": "sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.11.0.tgz",
+      "integrity": "sha512-HJh33bgzXe6jGRocOj4FmefD7hRY4itgjzOrSs3JPrTNXsX7j5+nQPciAUj/1nZtwo2kAc3C75jZO+T23gzSGw==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/type-utils": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.11.0",
+        "@typescript-eslint/type-utils": "5.11.0",
+        "@typescript-eslint/utils": "5.11.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -3152,66 +3138,15 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz",
-      "integrity": "sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==",
-      "extraneous": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "extraneous": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "extraneous": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/parser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.0.tgz",
-      "integrity": "sha512-/6pOPz8yAxEt4PLzgbFRDpZmHnXCeZgPDrh/1DaVKOjvn/UPMlWhbx/gA96xRi2JxY1kBl2AmwVbyROUqys5xQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.11.0.tgz",
+      "integrity": "sha512-x0DCjetHZYBRovJdr3U0zG9OOdNXUaFLJ82ehr1AlkArljJuwEsgnud+Q7umlGDFLFrs8tU8ybQDFocp/eX8mQ==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.11.0",
+        "@typescript-eslint/types": "5.11.0",
+        "@typescript-eslint/typescript-estree": "5.11.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -3231,13 +3166,13 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz",
-      "integrity": "sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz",
+      "integrity": "sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0"
+        "@typescript-eslint/types": "5.11.0",
+        "@typescript-eslint/visitor-keys": "5.11.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3248,12 +3183,12 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/type-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.0.tgz",
-      "integrity": "sha512-uVCb9dJXpBrK1071ri5aEW7ZHdDHAiqEjYznF3HSSvAJXyrkxGOw2Ejibz/q6BXdT8lea8CMI0CzKNFTNI6TEQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
+      "integrity": "sha512-wDqdsYO6ofLaD4DsGZ0jGwxp4HrzD2YKulpEZXmgN3xo4BHJwf7kq49JTRpV0Gx6bxkSUmc9s0EIK1xPbFFpIA==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
+        "@typescript-eslint/utils": "5.11.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -3274,9 +3209,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/types": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.0.tgz",
-      "integrity": "sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.11.0.tgz",
+      "integrity": "sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==",
       "extraneous": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3287,13 +3222,13 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz",
-      "integrity": "sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz",
+      "integrity": "sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0",
+        "@typescript-eslint/types": "5.11.0",
+        "@typescript-eslint/visitor-keys": "5.11.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -3313,13 +3248,64 @@
         }
       }
     },
-    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz",
-      "integrity": "sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==",
+    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/utils": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.11.0.tgz",
+      "integrity": "sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==",
       "extraneous": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.11.0",
+        "@typescript-eslint/types": "5.11.0",
+        "@typescript-eslint/typescript-estree": "5.11.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "extraneous": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "extraneous": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz",
+      "integrity": "sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==",
+      "extraneous": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.11.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3352,9 +3338,9 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3371,6 +3357,18 @@
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/acorn-jsx": {
@@ -3442,11 +3440,23 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/@pnp/cli-microsoft365/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/@pnp/cli-microsoft365/node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3584,20 +3594,20 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/applicationinsights": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.2.0.tgz",
-      "integrity": "sha512-zb6b1wchJwnCH+PghmxDbygQtWW11lz8YsHbZ6o89kR8EbE/2lO9VwNCxMtU1H1f7RQbiIZuNEnFR7wb8Ah4qA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.2.1.tgz",
+      "integrity": "sha512-N6panMyjw6E6ayCgjFDBmL/NkaolgBgeX1iJ0jh50E6wrncVJBCa+I4IelwwOfJ4Dl9BWzOSLjp84wTiUyhNwg==",
       "dev": true,
       "dependencies": {
-        "@azure/core-http": "^2.2.2",
-        "@opentelemetry/api": "^1.0.3",
-        "@opentelemetry/core": "^0.23.0",
-        "@opentelemetry/semantic-conventions": "^0.24.0",
-        "@opentelemetry/tracing": "^0.23.0",
+        "@azure/core-http": "^2.2.3",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.0.0",
-        "diagnostic-channel-publishers": "1.0.3"
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.4"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -3669,7 +3679,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -3678,7 +3688,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3733,7 +3743,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": "*"
       }
@@ -3742,15 +3752,15 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/balanced-match": {
@@ -3783,7 +3793,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -3919,6 +3929,12 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
+    "node_modules/@pnp/cli-microsoft365/node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "extraneous": true
+    },
     "node_modules/@pnp/cli-microsoft365/node_modules/c8": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/c8/-/c8-7.11.0.tgz",
@@ -4016,7 +4032,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/chalk": {
       "version": "4.1.2",
@@ -4041,10 +4057,16 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "extraneous": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4252,7 +4274,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/coveralls": {
       "version": "3.1.1",
@@ -4336,7 +4358,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -4365,9 +4387,9 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -4391,9 +4413,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/decompress-response": {
@@ -4469,18 +4491,18 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/diagnostic-channel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.0.0.tgz",
-      "integrity": "sha512-v7Clmg5HG9XwIhqgbBRfwFzwZhxjvESZ33uu1cgcCLkdb9ZxgtY78eAgQMEQ39UecQ//4K5W75iq6LFBtAQD8w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
       "dev": true,
       "dependencies": {
         "semver": "^5.3.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.3.tgz",
-      "integrity": "sha512-RJJA1QYDHVJUpV3HYQx0TLFZLlqxRL1H5Z0Z8ywIiEHDunT9UMJKwcnWkKa/I0z3kwozg3PKfaNJP9OkIeqN2Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.4.tgz",
+      "integrity": "sha512-GDRAOrcNTPk4DhYzM2BauMnq7nKdFWmSFjWnEu8dT8Xf/ZXUbpORrqNAhIWsy2tqRjHG7QkmYjMUL4/EGSM2GA==",
       "dev": true,
       "peerDependencies": {
         "diagnostic-channel": "*"
@@ -4583,7 +4605,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4620,18 +4642,6 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "extraneous": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/es-abstract": {
@@ -4735,9 +4745,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/escodegen/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -4795,9 +4805,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "extraneous": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -4807,11 +4817,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -4820,7 +4829,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -4831,9 +4840,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -5193,6 +5200,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@pnp/cli-microsoft365/node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "extraneous": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@pnp/cli-microsoft365/node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -5212,6 +5228,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/eslint/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "extraneous": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/eslint/node_modules/js-yaml": {
@@ -5238,18 +5263,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/espree/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "extraneous": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/esprima": {
@@ -5329,7 +5342,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/external-editor": {
       "version": "3.1.0",
@@ -5349,21 +5362,21 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "extraneous": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5380,7 +5393,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5491,9 +5504,9 @@
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true,
       "funding": [
         {
@@ -5527,7 +5540,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": "*"
       }
@@ -5536,7 +5549,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5629,15 +5642,15 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "extraneous": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5781,7 +5794,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": ">=4"
       }
@@ -5790,7 +5803,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -5895,11 +5908,25 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "node_modules/@pnp/cli-microsoft365/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@pnp/cli-microsoft365/node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -5908,6 +5935,19 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/@pnp/cli-microsoft365/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/iconv-lite": {
@@ -6267,9 +6307,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/is-potential-custom-element-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/is-regex": {
@@ -6391,7 +6431,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/istanbul-lib-coverage": {
       "version": "3.0.1",
@@ -6430,9 +6470,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -6455,16 +6495,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/jsdom": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
-      "integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "dependencies": {
         "abab": "^2.0.5",
-        "acorn": "^8.1.0",
+        "acorn": "^8.2.4",
         "acorn-globals": "^6.0.0",
         "cssom": "^0.4.4",
         "cssstyle": "^2.3.0",
@@ -6472,12 +6512,13 @@
         "decimal.js": "^10.2.1",
         "domexception": "^2.0.1",
         "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
         "html-encoding-sniffer": "^2.0.1",
-        "is-potential-custom-element-name": "^1.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.0",
         "parse5": "6.0.1",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "saxes": "^5.0.1",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.0.0",
@@ -6487,23 +6528,33 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.4",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@pnp/cli-microsoft365/node_modules/jsdom/node_modules/acorn": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+    "node_modules/@pnp/cli-microsoft365/node_modules/jsdom/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">= 6"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/json-buffer": {
@@ -6516,13 +6567,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6534,7 +6585,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/json-to-ast": {
       "version": "2.1.0",
@@ -6605,10 +6656,10 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "extraneous": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -6756,7 +6807,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/lodash.once": {
       "version": "4.1.1",
@@ -6923,32 +6974,32 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
       "extraneous": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.2.0",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -7032,9 +7083,9 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "extraneous": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -7050,28 +7101,36 @@
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/nise": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
       "extraneous": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/node-fetch/node_modules/tr46": {
@@ -7097,9 +7156,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/node-forge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.0.tgz",
-      "integrity": "sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "dev": true,
       "engines": {
         "node": ">= 6.13.0"
@@ -7133,7 +7192,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": "*"
       }
@@ -7426,12 +7485,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "extraneous": true,
       "engines": {
         "node": ">=8.6"
@@ -7459,10 +7518,13 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-      "dev": true
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/process": {
       "version": "0.11.10",
@@ -7471,15 +7533,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "extraneous": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/psl": {
@@ -7523,7 +7576,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -7653,7 +7706,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -7723,7 +7776,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -7736,7 +7789,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
+      "extraneous": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -8001,30 +8054,21 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/sinon": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
-      "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
       "extraneous": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^8.1.0",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
         "diff": "^5.0.0",
-        "nise": "^5.1.0",
+        "nise": "^5.1.1",
         "supports-color": "^7.2.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/@pnp/cli-microsoft365/node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
-      "extraneous": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/slash": {
@@ -8046,6 +8090,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@pnp/cli-microsoft365/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "extraneous": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/@pnp/cli-microsoft365/node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8056,7 +8110,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8276,9 +8330,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/tr46": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
@@ -8333,7 +8387,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -8345,7 +8399,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/type-check": {
       "version": "0.4.0",
@@ -8387,9 +8441,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8501,7 +8555,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -8566,10 +8620,10 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "extraneous": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -8631,13 +8685,13 @@
       "dev": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/whatwg-url": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.7.0",
-        "tr46": "^2.0.2",
+        "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       },
       "engines": {
@@ -8697,9 +8751,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "extraneous": true
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/wrap-ansi": {
@@ -8735,9 +8789,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365/node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -19909,33 +19963,33 @@
       }
     },
     "@pnp/cli-microsoft365": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365/-/cli-microsoft365-4.4.0.tgz",
-      "integrity": "sha512-THENBs7lBaBaCM1x8DyGpnYAd0flKiBy7Su3PtEmD24yHWDdlH2bj0un4KwMuCPWj5yRjCMzc76ebjQVZ/7JuQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365/-/cli-microsoft365-5.0.0.tgz",
+      "integrity": "sha512-SwvVVmuhPHKgTY/zotF7p2OaoNb55+jA6WZkKdfUdxuihnd08GbG9dLhR3CeDZXWahI23ZSg1C056x3btynS7g==",
       "dev": true,
       "requires": {
-        "@azure/msal-node": "^1.5.0",
+        "@azure/msal-node": "^1.6.0",
         "@xmldom/xmldom": "^0.7.5",
         "adaptive-expressions": "^4.15.0",
         "adaptivecards": "^2.10.0",
         "adaptivecards-templating": "^2.2.0",
         "adm-zip": "^0.5.9",
-        "applicationinsights": "^2.2.0",
-        "axios": "^0.24.0",
+        "applicationinsights": "^2.2.1",
+        "axios": "^0.25.0",
         "chalk": "^4.1.2",
         "csv-stringify": "^6.0.5",
         "easy-table": "^1.2.0",
         "inquirer": "^8.2.0",
-        "jmespath": "^0.15.0",
+        "jmespath": "^0.16.0",
         "json-to-ast": "^2.1.0",
         "markshell": "^1.3.8",
         "minimist": "^1.2.5",
-        "node-forge": "^1.2.0",
+        "node-forge": "^1.2.1",
         "omelette": "^0.4.17",
         "open": "^8.4.0",
         "semver": "^7.3.4",
         "strip-json-comments": "^3.1.1",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "update-notifier": "^5.1.0",
         "uuid": "^8.3.2"
       },
@@ -19982,9 +20036,9 @@
           }
         },
         "@azure/core-http": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.2.tgz",
-          "integrity": "sha512-V1DdoO9V/sFimKpdWoNBgsE+QUjQgpXYnxrTdUp5RyhsTJjvEVn/HKmTQXIHuLUUo6IyIWj+B+Dg4VaXse9dIA==",
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.4.tgz",
+          "integrity": "sha512-QmmJmexXKtPyc3/rsZR/YTLDvMatzbzAypJmLzvlfxgz/SkgnqV/D4f6F2LsK6tBj1qhyp8BoXiOebiej0zz3A==",
           "dev": true,
           "requires": {
             "@azure/abort-controller": "^1.0.0",
@@ -19995,7 +20049,7 @@
             "@types/node-fetch": "^2.5.0",
             "@types/tunnel": "^0.0.3",
             "form-data": "^4.0.0",
-            "node-fetch": "^2.6.0",
+            "node-fetch": "^2.6.7",
             "process": "^0.11.10",
             "tough-cookie": "^4.0.0",
             "tslib": "^2.2.0",
@@ -20059,22 +20113,23 @@
           }
         },
         "@azure/msal-common": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
-          "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+          "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
           "dev": true,
           "requires": {
             "debug": "^4.1.1"
           }
         },
         "@azure/msal-node": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.5.0.tgz",
-          "integrity": "sha512-FiCra/3ZyLXSQltoI9ndeN/lvXsPsFDsqVKgH7SWXVQjL3OpEXiqKkj0CB2UWGCk1U6bZGMJfkUZCXzhMQTObQ==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.6.0.tgz",
+          "integrity": "sha512-RCPXVWsjqYZh7NB1pAJLn4ypHlLBulOjw5nKPLsJiaJJIXnN8kc6SMkK3S9/80DZCEBstvoRMz6zF50QZJUeOQ==",
           "dev": true,
           "requires": {
-            "@azure/msal-common": "^6.0.0",
+            "@azure/msal-common": "^6.1.0",
             "axios": "^0.21.4",
+            "https-proxy-agent": "^5.0.0",
             "jsonwebtoken": "^8.5.1",
             "uuid": "^8.3.0"
           },
@@ -20154,8 +20209,8 @@
           "extraneous": true
         },
         "@microsoft/microsoft-graph-types": {
-          "version": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.11.0.tgz",
-          "integrity": "sha512-v4Wuxp+kbcxeJGmb2UHbcukNr05XItFYXL+U3ReignI3Vl8tp1vfq0hkqP35Fun2QpqHJiu8Rkxj1MUF8d82ag==",
+          "version": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.13.0.tgz",
+          "integrity": "sha512-63FfWBLcyNo8tMP4oPcdqHQvk4ehuWpiUMjVLD7zJXPENIowpdwudP969AALkKzlwsjWImamdivGKd2Zc8Z1Uw==",
           "extraneous": true
         },
         "@microsoft/recognizers-text-data-types-timex-expression": {
@@ -20191,72 +20246,46 @@
           }
         },
         "@opentelemetry/api": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-          "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+          "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
           "dev": true
         },
         "@opentelemetry/core": {
-          "version": "0.23.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
-          "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+          "integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
           "dev": true,
           "requires": {
-            "@opentelemetry/semantic-conventions": "0.23.0",
-            "semver": "^7.1.3"
-          },
-          "dependencies": {
-            "@opentelemetry/semantic-conventions": {
-              "version": "0.23.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-              "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-              "dev": true
-            }
+            "@opentelemetry/semantic-conventions": "1.0.1"
           }
         },
         "@opentelemetry/resources": {
-          "version": "0.23.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
-          "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+          "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
           "dev": true,
           "requires": {
-            "@opentelemetry/core": "0.23.0",
-            "@opentelemetry/semantic-conventions": "0.23.0"
-          },
-          "dependencies": {
-            "@opentelemetry/semantic-conventions": {
-              "version": "0.23.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-              "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-              "dev": true
-            }
+            "@opentelemetry/core": "1.0.1",
+            "@opentelemetry/semantic-conventions": "1.0.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+          "integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.0.1",
+            "@opentelemetry/resources": "1.0.1",
+            "@opentelemetry/semantic-conventions": "1.0.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-          "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+          "integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
           "dev": true
-        },
-        "@opentelemetry/tracing": {
-          "version": "0.23.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.23.0.tgz",
-          "integrity": "sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "0.23.0",
-            "@opentelemetry/resources": "0.23.0",
-            "@opentelemetry/semantic-conventions": "0.23.0",
-            "lodash.merge": "^4.6.2"
-          },
-          "dependencies": {
-            "@opentelemetry/semantic-conventions": {
-              "version": "0.23.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-              "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-              "dev": true
-            }
-          }
         },
         "@sindresorhus/is": {
           "version": "0.14.0",
@@ -20274,18 +20303,18 @@
           }
         },
         "@sinonjs/fake-timers": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz",
+          "integrity": "sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==",
           "extraneous": true,
           "requires": {
             "@sinonjs/commons": "^1.7.0"
           }
         },
         "@sinonjs/samsam": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-          "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+          "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
           "extraneous": true,
           "requires": {
             "@sinonjs/commons": "^1.6.0",
@@ -20307,6 +20336,12 @@
           "requires": {
             "defer-to-connect": "^1.0.1"
           }
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+          "dev": true
         },
         "@types/adm-zip": {
           "version": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
@@ -20335,8 +20370,8 @@
           "extraneous": true
         },
         "@types/inquirer": {
-          "version": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
-          "integrity": "sha512-AayK4ZL5ssPzR1OtnOLGAwpT0Dda3Xi/h1G0l1oJDNrowp7T1423q4Zb8/emr7tzRlCy4ssEri0LWVexAqHyKQ==",
+          "version": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.0.tgz",
+          "integrity": "sha512-BNoMetRf3gmkpAlV5we+kxyZTle7YibdOntIZbU5pyIfMdcwy784KfeZDAcuyMznkh5OLa17RVXZOGA5LTlkgQ==",
           "extraneous": true,
           "requires": {
             "@types/through": "*",
@@ -20398,14 +20433,14 @@
           "extraneous": true
         },
         "@types/mocha": {
-          "version": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-          "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+          "version": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+          "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
           "extraneous": true
         },
         "@types/node": {
-          "version": "16.11.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-          "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+          "version": "16.11.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
+          "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
           "dev": true
         },
         "@types/node-fetch": {
@@ -20445,12 +20480,18 @@
           "extraneous": true
         },
         "@types/sinon": {
-          "version": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
-          "integrity": "sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==",
+          "version": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
+          "integrity": "sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==",
           "extraneous": true,
           "requires": {
-            "@sinonjs/fake-timers": "^7.1.0"
+            "@types/sinonjs__fake-timers": "*"
           }
+        },
+        "@types/sinonjs__fake-timers": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+          "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+          "extraneous": true
         },
         "@types/through": {
           "version": "0.0.30",
@@ -20491,13 +20532,13 @@
           "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-          "version": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
-          "integrity": "sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==",
+          "version": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.11.0.tgz",
+          "integrity": "sha512-HJh33bgzXe6jGRocOj4FmefD7hRY4itgjzOrSs3JPrTNXsX7j5+nQPciAUj/1nZtwo2kAc3C75jZO+T23gzSGw==",
           "extraneous": true,
           "requires": {
-            "@typescript-eslint/experimental-utils": "5.9.0",
-            "@typescript-eslint/scope-manager": "5.9.0",
-            "@typescript-eslint/type-utils": "5.9.0",
+            "@typescript-eslint/scope-manager": "5.11.0",
+            "@typescript-eslint/type-utils": "5.11.0",
+            "@typescript-eslint/utils": "5.11.0",
             "debug": "^4.3.2",
             "functional-red-black-tree": "^1.0.1",
             "ignore": "^5.1.8",
@@ -20514,16 +20555,70 @@
             }
           }
         },
-        "@typescript-eslint/experimental-utils": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz",
-          "integrity": "sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==",
+        "@typescript-eslint/parser": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.11.0.tgz",
+          "integrity": "sha512-x0DCjetHZYBRovJdr3U0zG9OOdNXUaFLJ82ehr1AlkArljJuwEsgnud+Q7umlGDFLFrs8tU8ybQDFocp/eX8mQ==",
+          "extraneous": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "5.11.0",
+            "@typescript-eslint/types": "5.11.0",
+            "@typescript-eslint/typescript-estree": "5.11.0",
+            "debug": "^4.3.2"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz",
+          "integrity": "sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==",
+          "extraneous": true,
+          "requires": {
+            "@typescript-eslint/types": "5.11.0",
+            "@typescript-eslint/visitor-keys": "5.11.0"
+          }
+        },
+        "@typescript-eslint/type-utils": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
+          "integrity": "sha512-wDqdsYO6ofLaD4DsGZ0jGwxp4HrzD2YKulpEZXmgN3xo4BHJwf7kq49JTRpV0Gx6bxkSUmc9s0EIK1xPbFFpIA==",
+          "extraneous": true,
+          "requires": {
+            "@typescript-eslint/utils": "5.11.0",
+            "debug": "^4.3.2",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.11.0.tgz",
+          "integrity": "sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==",
+          "extraneous": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz",
+          "integrity": "sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==",
+          "extraneous": true,
+          "requires": {
+            "@typescript-eslint/types": "5.11.0",
+            "@typescript-eslint/visitor-keys": "5.11.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.11.0.tgz",
+          "integrity": "sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==",
           "extraneous": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.9.0",
-            "@typescript-eslint/types": "5.9.0",
-            "@typescript-eslint/typescript-estree": "5.9.0",
+            "@typescript-eslint/scope-manager": "5.11.0",
+            "@typescript-eslint/types": "5.11.0",
+            "@typescript-eslint/typescript-estree": "5.11.0",
             "eslint-scope": "^5.1.1",
             "eslint-utils": "^3.0.0"
           },
@@ -20545,67 +20640,13 @@
             }
           }
         },
-        "@typescript-eslint/parser": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.0.tgz",
-          "integrity": "sha512-/6pOPz8yAxEt4PLzgbFRDpZmHnXCeZgPDrh/1DaVKOjvn/UPMlWhbx/gA96xRi2JxY1kBl2AmwVbyROUqys5xQ==",
-          "extraneous": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "5.9.0",
-            "@typescript-eslint/types": "5.9.0",
-            "@typescript-eslint/typescript-estree": "5.9.0",
-            "debug": "^4.3.2"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz",
-          "integrity": "sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==",
-          "extraneous": true,
-          "requires": {
-            "@typescript-eslint/types": "5.9.0",
-            "@typescript-eslint/visitor-keys": "5.9.0"
-          }
-        },
-        "@typescript-eslint/type-utils": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.0.tgz",
-          "integrity": "sha512-uVCb9dJXpBrK1071ri5aEW7ZHdDHAiqEjYznF3HSSvAJXyrkxGOw2Ejibz/q6BXdT8lea8CMI0CzKNFTNI6TEQ==",
-          "extraneous": true,
-          "requires": {
-            "@typescript-eslint/experimental-utils": "5.9.0",
-            "debug": "^4.3.2",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.0.tgz",
-          "integrity": "sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==",
-          "extraneous": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz",
-          "integrity": "sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==",
-          "extraneous": true,
-          "requires": {
-            "@typescript-eslint/types": "5.9.0",
-            "@typescript-eslint/visitor-keys": "5.9.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz",
-          "integrity": "sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==",
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz",
+          "integrity": "sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==",
           "extraneous": true,
           "requires": {
-            "@typescript-eslint/types": "5.9.0",
+            "@typescript-eslint/types": "5.11.0",
             "eslint-visitor-keys": "^3.0.0"
           }
         },
@@ -20628,9 +20669,9 @@
           "dev": true
         },
         "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
           "dev": true
         },
         "acorn-globals": {
@@ -20641,6 +20682,14 @@
           "requires": {
             "acorn": "^7.1.1",
             "acorn-walk": "^7.1.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+              "dev": true
+            }
           }
         },
         "acorn-jsx": {
@@ -20702,11 +20751,20 @@
           "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
           "dev": true
         },
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
         "ajv": {
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -20818,20 +20876,20 @@
           }
         },
         "applicationinsights": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.2.0.tgz",
-          "integrity": "sha512-zb6b1wchJwnCH+PghmxDbygQtWW11lz8YsHbZ6o89kR8EbE/2lO9VwNCxMtU1H1f7RQbiIZuNEnFR7wb8Ah4qA==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.2.1.tgz",
+          "integrity": "sha512-N6panMyjw6E6ayCgjFDBmL/NkaolgBgeX1iJ0jh50E6wrncVJBCa+I4IelwwOfJ4Dl9BWzOSLjp84wTiUyhNwg==",
           "dev": true,
           "requires": {
-            "@azure/core-http": "^2.2.2",
-            "@opentelemetry/api": "^1.0.3",
-            "@opentelemetry/core": "^0.23.0",
-            "@opentelemetry/semantic-conventions": "^0.24.0",
-            "@opentelemetry/tracing": "^0.23.0",
+            "@azure/core-http": "^2.2.3",
+            "@opentelemetry/api": "^1.0.4",
+            "@opentelemetry/core": "^1.0.1",
+            "@opentelemetry/sdk-trace-base": "^1.0.1",
+            "@opentelemetry/semantic-conventions": "^1.0.1",
             "cls-hooked": "^4.2.2",
             "continuation-local-storage": "^3.2.1",
-            "diagnostic-channel": "1.0.0",
-            "diagnostic-channel-publishers": "1.0.3"
+            "diagnostic-channel": "1.1.0",
+            "diagnostic-channel-publishers": "1.0.4"
           }
         },
         "argparse": {
@@ -20877,7 +20935,7 @@
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
@@ -20886,7 +20944,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "extraneous": true
         },
         "async-hook-jl": {
           "version": "1.7.6",
@@ -20931,21 +20989,21 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
+          "extraneous": true
         },
         "aws4": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
           "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-          "dev": true
+          "extraneous": true
         },
         "axios": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
           "dev": true,
           "requires": {
-            "follow-redirects": "^1.14.4"
+            "follow-redirects": "^1.14.7"
           }
         },
         "balanced-match": {
@@ -20964,7 +21022,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
@@ -21073,6 +21131,12 @@
           "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
           "dev": true
         },
+        "buffer-from": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+          "extraneous": true
+        },
         "c8": {
           "version": "https://registry.npmjs.org/c8/-/c8-7.11.0.tgz",
           "integrity": "sha512-XqPyj1uvlHMr+Y1IeRndC2X5P7iJzJlEJwBpCdBbq2JocXOgJfr+JVfJkyNMGROke5LfKrhSFXGFXnwnRJAUJw==",
@@ -21150,7 +21214,7 @@
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
+          "extraneous": true
         },
         "chalk": {
           "version": "4.1.2",
@@ -21169,9 +21233,9 @@
           "dev": true
         },
         "chokidar": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+          "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
           "extraneous": true,
           "requires": {
             "anymatch": "~3.1.2",
@@ -21343,7 +21407,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "extraneous": true
         },
         "coveralls": {
           "version": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
@@ -21413,7 +21477,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -21436,9 +21500,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -21451,9 +21515,9 @@
           "extraneous": true
         },
         "decimal.js": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-          "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
           "dev": true
         },
         "decompress-response": {
@@ -21514,9 +21578,9 @@
           "dev": true
         },
         "diagnostic-channel": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.0.0.tgz",
-          "integrity": "sha512-v7Clmg5HG9XwIhqgbBRfwFzwZhxjvESZ33uu1cgcCLkdb9ZxgtY78eAgQMEQ39UecQ//4K5W75iq6LFBtAQD8w==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+          "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
@@ -21531,9 +21595,9 @@
           }
         },
         "diagnostic-channel-publishers": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.3.tgz",
-          "integrity": "sha512-RJJA1QYDHVJUpV3HYQx0TLFZLlqxRL1H5Z0Z8ywIiEHDunT9UMJKwcnWkKa/I0z3kwozg3PKfaNJP9OkIeqN2Q==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.4.tgz",
+          "integrity": "sha512-GDRAOrcNTPk4DhYzM2BauMnq7nKdFWmSFjWnEu8dT8Xf/ZXUbpORrqNAhIWsy2tqRjHG7QkmYjMUL4/EGSM2GA==",
           "dev": true,
           "requires": {}
         },
@@ -21607,7 +21671,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -21644,15 +21708,6 @@
           "dev": true,
           "requires": {
             "once": "^1.4.0"
-          }
-        },
-        "enquirer": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-          "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-          "extraneous": true,
-          "requires": {
-            "ansi-colors": "^4.1.1"
           }
         },
         "es-abstract": {
@@ -21726,9 +21781,9 @@
           },
           "dependencies": {
             "estraverse": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
               "dev": true
             },
             "levn": {
@@ -21773,9 +21828,9 @@
           }
         },
         "eslint": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-          "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+          "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
           "extraneous": true,
           "requires": {
             "@eslint/eslintrc": "^1.0.5",
@@ -21785,11 +21840,10 @@
             "cross-spawn": "^7.0.2",
             "debug": "^4.3.2",
             "doctrine": "^3.0.0",
-            "enquirer": "^2.3.5",
             "escape-string-regexp": "^4.0.0",
             "eslint-scope": "^7.1.0",
             "eslint-utils": "^3.0.0",
-            "eslint-visitor-keys": "^3.1.0",
+            "eslint-visitor-keys": "^3.2.0",
             "espree": "^9.3.0",
             "esquery": "^1.4.0",
             "esutils": "^2.0.2",
@@ -21798,7 +21852,7 @@
             "functional-red-black-tree": "^1.0.1",
             "glob-parent": "^6.0.1",
             "globals": "^13.6.0",
-            "ignore": "^4.0.6",
+            "ignore": "^5.2.0",
             "import-fresh": "^3.0.0",
             "imurmurhash": "^0.1.4",
             "is-glob": "^4.0.0",
@@ -21809,9 +21863,7 @@
             "minimatch": "^3.0.4",
             "natural-compare": "^1.4.0",
             "optionator": "^0.9.1",
-            "progress": "^2.0.0",
             "regexpp": "^3.2.0",
-            "semver": "^7.2.1",
             "strip-ansi": "^6.0.1",
             "strip-json-comments": "^3.1.0",
             "text-table": "^0.2.0",
@@ -21857,6 +21909,12 @@
                 }
               }
             },
+            "eslint-visitor-keys": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+              "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+              "extraneous": true
+            },
             "estraverse": {
               "version": "5.3.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -21871,6 +21929,12 @@
               "requires": {
                 "is-glob": "^4.0.3"
               }
+            },
+            "ignore": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+              "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+              "extraneous": true
             },
             "js-yaml": {
               "version": "4.1.0",
@@ -22111,14 +22175,6 @@
             "acorn": "^8.7.0",
             "acorn-jsx": "^5.3.1",
             "eslint-visitor-keys": "^3.1.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "8.7.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-              "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-              "extraneous": true
-            }
           }
         },
         "esprima": {
@@ -22177,7 +22233,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-          "dev": true
+          "extraneous": true
         },
         "external-editor": {
           "version": "3.1.0",
@@ -22194,18 +22250,18 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
+          "extraneous": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
+          "extraneous": true
         },
         "fast-glob": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-          "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
           "extraneous": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -22219,7 +22275,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
           "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-          "dev": true
+          "extraneous": true
         },
         "fast-levenshtein": {
           "version": "2.0.6",
@@ -22305,9 +22361,9 @@
           "extraneous": true
         },
         "follow-redirects": {
-          "version": "1.14.4",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-          "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+          "version": "1.14.8",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+          "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
           "dev": true
         },
         "foreground-child": {
@@ -22324,13 +22380,13 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
+          "extraneous": true
         },
         "form-data": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -22401,15 +22457,15 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "extraneous": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -22518,13 +22574,13 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-          "dev": true
+          "extraneous": true
         },
         "har-validator": {
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
           "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
@@ -22599,15 +22655,36 @@
           "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
           "dev": true
         },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
         "http-signature": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
             "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "iconv-lite": {
@@ -22854,9 +22931,9 @@
           "extraneous": true
         },
         "is-potential-custom-element-name": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-          "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+          "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
           "dev": true
         },
         "is-regex": {
@@ -22945,7 +23022,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
+          "extraneous": true
         },
         "istanbul-lib-coverage": {
           "version": "3.0.1",
@@ -22975,9 +23052,9 @@
           }
         },
         "jmespath": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-          "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+          "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
           "dev": true
         },
         "js-yaml": {
@@ -22994,16 +23071,16 @@
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true
+          "extraneous": true
         },
         "jsdom": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
-          "integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
+          "version": "16.7.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+          "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
           "dev": true,
           "requires": {
             "abab": "^2.0.5",
-            "acorn": "^8.1.0",
+            "acorn": "^8.2.4",
             "acorn-globals": "^6.0.0",
             "cssom": "^0.4.4",
             "cssstyle": "^2.3.0",
@@ -23011,12 +23088,13 @@
             "decimal.js": "^10.2.1",
             "domexception": "^2.0.1",
             "escodegen": "^2.0.0",
+            "form-data": "^3.0.0",
             "html-encoding-sniffer": "^2.0.1",
-            "is-potential-custom-element-name": "^1.0.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-potential-custom-element-name": "^1.0.1",
             "nwsapi": "^2.2.0",
             "parse5": "6.0.1",
-            "request": "^2.88.2",
-            "request-promise-native": "^1.0.9",
             "saxes": "^5.0.1",
             "symbol-tree": "^3.2.4",
             "tough-cookie": "^4.0.0",
@@ -23026,15 +23104,20 @@
             "whatwg-encoding": "^1.0.5",
             "whatwg-mimetype": "^2.3.0",
             "whatwg-url": "^8.5.0",
-            "ws": "^7.4.4",
+            "ws": "^7.4.6",
             "xml-name-validator": "^3.0.0"
           },
           "dependencies": {
-            "acorn": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-              "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
-              "dev": true
+            "form-data": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+              "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
             }
           }
         },
@@ -23048,13 +23131,13 @@
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
+          "extraneous": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "extraneous": true
         },
         "json-stable-stringify-without-jsonify": {
           "version": "1.0.1",
@@ -23066,7 +23149,7 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
+          "extraneous": true
         },
         "json-to-ast": {
           "version": "2.1.0",
@@ -23123,7 +23206,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -23259,7 +23342,7 @@
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
           "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-          "dev": true
+          "extraneous": true
         },
         "lodash.once": {
           "version": "4.1.1",
@@ -23386,31 +23469,31 @@
           "dev": true
         },
         "mocha": {
-          "version": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-          "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+          "version": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+          "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
           "extraneous": true,
           "requires": {
             "@ungap/promise-all-settled": "1.1.2",
             "ansi-colors": "4.1.1",
             "browser-stdout": "1.3.1",
-            "chokidar": "3.5.2",
-            "debug": "4.3.2",
+            "chokidar": "3.5.3",
+            "debug": "4.3.3",
             "diff": "5.0.0",
             "escape-string-regexp": "4.0.0",
             "find-up": "5.0.0",
-            "glob": "7.1.7",
+            "glob": "7.2.0",
             "growl": "1.10.5",
             "he": "1.2.0",
             "js-yaml": "4.1.0",
             "log-symbols": "4.1.0",
             "minimatch": "3.0.4",
             "ms": "2.1.3",
-            "nanoid": "3.1.25",
+            "nanoid": "3.2.0",
             "serialize-javascript": "6.0.0",
             "strip-json-comments": "3.1.1",
             "supports-color": "8.1.1",
             "which": "2.0.2",
-            "workerpool": "6.1.5",
+            "workerpool": "6.2.0",
             "yargs": "16.2.0",
             "yargs-parser": "20.2.4",
             "yargs-unparser": "2.0.0"
@@ -23473,9 +23556,9 @@
           "dev": true
         },
         "nanoid": {
-          "version": "3.1.25",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-          "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+          "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
           "extraneous": true
         },
         "natural-compare": {
@@ -23485,22 +23568,22 @@
           "extraneous": true
         },
         "nise": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-          "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+          "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
           "extraneous": true,
           "requires": {
-            "@sinonjs/commons": "^1.7.0",
-            "@sinonjs/fake-timers": "^7.0.4",
+            "@sinonjs/commons": "^1.8.3",
+            "@sinonjs/fake-timers": ">=5",
             "@sinonjs/text-encoding": "^0.7.1",
             "just-extend": "^4.0.2",
             "path-to-regexp": "^1.7.0"
           }
         },
         "node-fetch": {
-          "version": "2.6.6",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
           "dev": true,
           "requires": {
             "whatwg-url": "^5.0.0"
@@ -23531,9 +23614,9 @@
           }
         },
         "node-forge": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.0.tgz",
-          "integrity": "sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+          "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
           "dev": true
         },
         "normalize-path": {
@@ -23558,7 +23641,7 @@
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-          "dev": true
+          "extraneous": true
         },
         "object-inspect": {
           "version": "1.11.0",
@@ -23775,12 +23858,12 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
+          "extraneous": true
         },
         "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "extraneous": true
         },
         "prelude-ls": {
@@ -23796,9 +23879,9 @@
           "dev": true
         },
         "prismjs": {
-          "version": "1.24.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+          "version": "1.26.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+          "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
           "dev": true
         },
         "process": {
@@ -23806,12 +23889,6 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
-        },
-        "progress": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-          "extraneous": true
         },
         "psl": {
           "version": "1.8.0",
@@ -23848,7 +23925,7 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
+          "extraneous": true
         },
         "queue-microtask": {
           "version": "1.2.3",
@@ -23939,7 +24016,7 @@
           "version": "2.88.2",
           "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
           "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -23967,7 +24044,7 @@
               "version": "2.5.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
               "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-              "dev": true,
+              "extraneous": true,
               "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -23977,7 +24054,7 @@
               "version": "3.4.0",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
               "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-              "dev": true
+              "extraneous": true
             }
           }
         },
@@ -23991,8 +24068,7 @@
           }
         },
         "request-promise-native": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+          "version": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
           "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
           "dev": true,
           "requires": {
@@ -24219,27 +24295,16 @@
           "dev": true
         },
         "sinon": {
-          "version": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
-          "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+          "version": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+          "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
           "extraneous": true,
           "requires": {
             "@sinonjs/commons": "^1.8.3",
-            "@sinonjs/fake-timers": "^8.1.0",
-            "@sinonjs/samsam": "^6.0.2",
+            "@sinonjs/fake-timers": "^9.0.0",
+            "@sinonjs/samsam": "^6.1.1",
             "diff": "^5.0.0",
-            "nise": "^5.1.0",
+            "nise": "^5.1.1",
             "supports-color": "^7.2.0"
-          },
-          "dependencies": {
-            "@sinonjs/fake-timers": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-              "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
-              "extraneous": true,
-              "requires": {
-                "@sinonjs/commons": "^1.7.0"
-              }
-            }
           }
         },
         "slash": {
@@ -24255,6 +24320,15 @@
           "dev": true,
           "optional": true
         },
+        "source-map-support": {
+          "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "extraneous": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -24265,7 +24339,7 @@
           "version": "1.16.1",
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
           "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -24437,9 +24511,9 @@
           }
         },
         "tr46": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
           "dev": true,
           "requires": {
             "punycode": "^2.1.1"
@@ -24482,7 +24556,7 @@
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -24491,7 +24565,7 @@
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true
+          "extraneous": true
         },
         "type-check": {
           "version": "0.4.0",
@@ -24524,9 +24598,9 @@
           }
         },
         "typescript": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-          "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
           "dev": true
         },
         "unbox-primitive": {
@@ -24612,7 +24686,7 @@
           "version": "4.4.1",
           "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
           "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "punycode": "^2.1.0"
           }
@@ -24667,7 +24741,7 @@
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -24723,13 +24797,13 @@
           "dev": true
         },
         "whatwg-url": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-          "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "requires": {
             "lodash": "^4.7.0",
-            "tr46": "^2.0.2",
+            "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
         },
@@ -24771,9 +24845,9 @@
           "dev": true
         },
         "workerpool": {
-          "version": "6.1.5",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-          "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
           "extraneous": true
         },
         "wrap-ansi": {
@@ -24806,9 +24880,9 @@
           }
         },
         "ws": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
           "dev": true,
           "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "update:manifest": "node scripts/update-manifest.js myuniquedomain.loca.lt",
     "update:teams-app": "node scripts/update-teams-app.js ",
     "m365:login": "m365 login",
-    "m365:create-aad-app": "m365 aad app add --manifest @aad-app-manifest.json --save",
+    "m365:create-aad-app": "m365 aad app add --manifest @aad-app-manifest.json --uri \"api://myuniquedomain.loca.lt/_appId_\" --save",
     "m365:package": "npm run update:manifest -s && cd package && npx bestzip \"../angular-teams.zip\" \"*\"",
     "m365:publish": "npm run m365:package -s && m365 teams app publish -p angular-teams.zip",
     "m365:update": "npm run m365:package -s && npm run update:teams-app -s"
@@ -38,7 +38,7 @@
     "@angular-devkit/build-angular": "~13.2.2",
     "@angular/cli": "~13.2.2",
     "@angular/compiler-cli": "~13.2.0",
-    "@pnp/cli-microsoft365": "^4.4.0",
+    "@pnp/cli-microsoft365": "^5.0.0",
     "@types/jasmine": "~3.10.0",
     "@types/node": "^12.11.1",
     "bestzip": "^2.2.0",

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -42,7 +42,7 @@
   ],
   "validDomains": [],
   "webApplicationInfo": {
-    "id": "ff254847-12c7-44cf-921e-8883dbd622a7",
-    "resource": "api://myuniquedomain.loca.lt/ff254847-12c7-44cf-921e-8883dbd622a7"
+    "id": "fc51be1e-1870-4300-a6e6-e853c57577b4",
+    "resource": "api://myuniquedomain.loca.lt/fc51be1e-1870-4300-a6e6-e853c57577b4"
   }
 }

--- a/scripts/update-teams-app.js
+++ b/scripts/update-teams-app.js
@@ -7,45 +7,37 @@ const fs = require('fs');
 const process = require('process');
 const { execSync } = require('child_process');
 
-const defaultExternalAppId = '933b8170-ad4c-421f-b2ca-a80f2685ef08';
-const m365rcPath = path.join(__dirname, '../.m365rc.json');
-const usage = `Usage: node ${path.basename(process.argv[1])} [externalAppId]`;
+const manifestPath = path.join(__dirname, '../package/manifest.json');
+const usage = `Usage: node ${path.basename(process.argv[1])}`;
 
 run();
 
 // ---------------------------------------------------------------------------
 
 function run() {
-  const args = process.argv.slice(2);
-
-  if (args.length > 1) {
-    console.error(usage);
-    process.exit(-1);
-  }
-
-  const externalAppId = args[0] || process.env.EXTERNAL_APP_ID || defaultExternalAppId;
-  const appId = getAppId(externalAppId);
+  const teamsAppName = getTeamsAppName();
 
   try {
-    if (!appId) {
-      throw new Error('Unable to retrieve internal appId.');
+    if (!teamsAppName) {
+      throw new Error(`Unable to retrieve Teams app's name.`);
     }
 
-    console.log(`Updating Teams app with appId: ${appId}...`);
-    execSync(`m365 teams app update -i ${appId} -p angular-teams.zip`);
+    console.log(`Updating Teams app ${teamsAppName}...`);
+    execSync(`m365 teams app update --name "${teamsAppName}" --filePath angular-teams.zip`);
     console.log('Done!');
   } catch {
-    console.error('Error updating teams app!');
+    console.error('Error updating Teams app!');
     process.exit(-1);
   }
 }
 
-function getAppId(externalAppId) {
-  try {
-    console.log('Retrieving internal appId...');
-    const appId = execSync(`m365 teams app list --query "[?externalId == '${externalAppId}'] | [0].id"`).toString();
-    return JSON.parse(appId);
-  } catch {
-    return null;
+function getTeamsAppName() {
+  console.log(`Retrieving Teams app's name...`);
+  const manifestContents = fs.readFileSync(manifestPath, 'utf8');
+  if (!manifestContents) {
+    throw new Error(`Unable to read file: ${manifestPath}`);
   }
+
+  const manifest = JSON.parse(manifestContents);
+  return manifest.name?.short;
 }


### PR DESCRIPTION
- adds .m365rc.json to .gitignore so that devs won't commit their AAD app config to source control
- extends AAD app manifest with pre-authorized applications to complete Teams SSO configuration
- extends the m365:create-aad-app script to properly set the AAD app URI for Teams SSO
- updates CLI for M365 to v5 which has the API for running commands from scripts and contains latest improvements for configuring AAD apps
- simplifies the update-teams-app.js script to use Teams app's name to update the app rather than its ID